### PR TITLE
Use a server side timer for UI refresh period

### DIFF
--- a/lib/ambi.ex
+++ b/lib/ambi.ex
@@ -17,8 +17,9 @@ defmodule Ambi do
     %Ambi.Reading{}
     |> Ambi.Reading.changeset(attrs)
     |> Repo.insert()
-    broadcast_change(:added)
-    Logger.debug "Added new reading and called broadcast_change()"
+    #broadcast_change(:added)
+    #Logger.debug "Added new reading and called broadcast_change()"
+    Logger.debug "Added new reading to the DB"
   end
 
   def get_reading() do
@@ -112,7 +113,7 @@ defmodule Ambi do
     """
   end
 
-  defp broadcast_change(event) do
+  def broadcast_change(event) do
     PubSub.broadcast(Ambi.PubSub, @topic, event)
     Logger.debug """
     Broadcast details:

--- a/lib/ambi/application.ex
+++ b/lib/ambi/application.ex
@@ -14,7 +14,9 @@ defmodule Ambi.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: Ambi.PubSub},
       # Start the Endpoint (http/https)
-      AmbiWeb.Endpoint
+      AmbiWeb.Endpoint,
+      # Start our timer module
+      Ambi.Timer
       # Start a worker by calling: Ambi.Worker.start_link(arg)
       # {Ambi.Worker, arg}
     ]

--- a/lib/ambi/timer.ex
+++ b/lib/ambi/timer.ex
@@ -1,0 +1,30 @@
+defmodule Ambi.Timer do
+  use GenServer
+  require Logger
+
+  def start_link(state) do
+    GenServer.start_link(__MODULE__, state, name: __MODULE__)
+  end
+  ## SERVER ##
+
+  def init(_state) do
+    Logger.warn "Ambi timer server started"
+    broadcast()
+    schedule_timer(10_000) # 1 sec timer
+    {:ok, 0}
+  end
+
+  def handle_info(:update, _time) do
+    broadcast()
+    schedule_timer(10_000)
+    {:noreply, 0}
+  end
+
+  defp schedule_timer(interval) do
+    Process.send_after(self(), :update, interval)
+  end
+
+  defp broadcast() do
+    Ambi.broadcast_change(:reading_refresh)
+  end
+end

--- a/lib/ambi_web/live/reading_live.ex
+++ b/lib/ambi_web/live/reading_live.ex
@@ -4,7 +4,7 @@ defmodule AmbiWeb.ReadingLive do
   require Logger
 
   def mount(_params, _session, socket) do
-    Logger.debug "mount() called, subscribing to :added event"
+    Logger.debug "ReadingLive.mount() called, subscribing PubSub topic"
     Ambi.subscribe()
 
     {:ok, assign(socket, %{reading: Ambi.get_reading()})}
@@ -12,6 +12,12 @@ defmodule AmbiWeb.ReadingLive do
 
   def handle_info(:added, socket) do
     Logger.debug "Received :added event message"
+    #{:noreply, assign(socket, %{reading: Ambi.get_reading()})}
+    {:noreply, assign(socket, %{})}
+  end
+
+  def handle_info(:reading_refresh, socket) do
+    Logger.debug "Received :refresh_reading event message"
     {:noreply, assign(socket, %{reading: Ambi.get_reading()})}
   end
 


### PR DESCRIPTION
Use a server side timer to set the frontend reading display refresh period. This removes use of the :add_reading PubSub event, although I haven't completely removed it yet since it could still prove to be useful for other future things.