### PR TITLE
Add 24hr humidity graph

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -60,19 +60,18 @@ hooks.humidity_chart = {
 
         var humidity_chart = new Chart(ctx, {
             // The type of chart we want to create
-            type: 'line',
+            type: 'bar',
             // The data for our dataset
             data: {
-                labels: ['0s', '5s', '10s', '15s',
-                            '20s', '25s', '30s', '35s',
-                            '40s', '45s', '50s', '55s',
-                            '60s', '65s', '70s', '75s',
-                            '80s', '85s', '90s', '95s',
-                            '100s', '105s', '110s', '115s',
-                            '120s'
+                labels: ['24', '23', '22', '21',
+                         '20', '19', '18', '17',
+                         '16', '15', '14', '13',
+                         '12', '11', '10', '9',
+                         '8', '7', '6', '5',
+                         '4', '3', '2', '1'
                         ],
                 datasets: [{
-                    label: 'Humidity %',
+                    label: 'Avg Humidity % 24 hrs',
                     backgroundColor: 'rgb(57, 154, 218)',
                     borderColor: 'rgb(200, 200, 200)'
                 }]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,11 @@ database_url = System.get_env("DATABASE_URL")
 
 # Configure your database
 config :ambi, Ambi.Repo,
-  url: database_url,
+ # url: database_url,
+  username: "postgres",
+  password: "postgres",
+  database: "ambi_dev",
+  hostname: "localhost",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/lib/ambi/reading_metadata.ex
+++ b/lib/ambi/reading_metadata.ex
@@ -1,0 +1,23 @@
+defmodule Ambi.ReadingMetadata do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "reading_metadata" do
+    field :timestamp_resolution_seconds, :integer
+  end
+
+  @spec changeset(
+          {map, map}
+          | %{
+              :__struct__ => atom | %{:__changeset__ => map, optional(any) => any},
+              optional(atom) => any
+            },
+          :invalid | %{optional(:__struct__) => none, optional(atom | binary) => any}
+        ) :: Ecto.Changeset.t()
+  @doc false
+  def changeset(reading, attrs) do
+    reading
+    |> cast(attrs, [:timestamp_resolution_seconds])
+    |> validate_required([:timestamp_resolution_seconds])
+  end
+end

--- a/lib/ambi_web/controllers/api_controller.ex
+++ b/lib/ambi_web/controllers/api_controller.ex
@@ -8,6 +8,13 @@ defmodule AmbiWeb.ApiController do
     render(conn, "api_response.json", status: status)
   end
 
+  def set_metadata(conn, params) do
+    Ambi.set_reading_metadata(params)
+
+    status = %{code: "ok", desc: "Reading metadata set successfully"}
+    render(conn, "api_response.json", status: status)
+  end
+
   def reset(conn, _params) do
     Ambi.reset_readings()
     html(conn, """

--- a/lib/ambi_web/live/reading_live.ex
+++ b/lib/ambi_web/live/reading_live.ex
@@ -24,15 +24,16 @@ defmodule AmbiWeb.ReadingLive do
     }
   end
 
-  #defp get_points, do: 1..7 |> Enum.map(fn _ -> :rand.uniform(100) end)
-
   defp get_temperatures do
     list = Ambi.get_temperatures_over_120s()
     Enum.flat_map(list, fn ({value}) -> [Float.round(value)] end)
   end
 
   defp get_humidities do
-    list = Ambi.get_humidities_over_120s()
-    Enum.flat_map(list, fn ({value}) -> [Float.round(value)] end)
+    #timestamp_resolution_seconds = Ambi.get_timestamp_resolution_seconds()
+    #Logger.debug "****** #{inspect(timestamp_resolution_seconds)}"
+    #label_every_nth_point = div(86000, timestamp_resolution_seconds)
+
+    Ambi.get_avg_humidities_over_24hrs()
   end
 end

--- a/lib/ambi_web/live/reading_live.html.leex
+++ b/lib/ambi_web/live/reading_live.html.leex
@@ -33,7 +33,20 @@
           </article>
         </div>
         <div class="tile is-parent is-vertical">
-          <article class="tile is-child notification">
+          <article class="tile is-child notification
+          <%= cond do %>
+              <%= @reading.humidity < 25 -> %>
+                is-danger
+              <%= @reading.humidity >= 25 and @reading.humidity < 30 -> %>
+                is-warning
+              <%= @reading.humidity >= 50 and @reading.humidity < 60 -> %>
+                is-warning
+              <%= @reading.humidity >= 60 -> %>
+                is-danger
+              <%= true -> %>
+                notification
+            <%= end %>
+          ">
             <p class="title">Humidity</p>
             <p class="subtitle"><%= Float.round(@reading.humidity, 1) %>%</p>
           </article>

--- a/lib/ambi_web/router.ex
+++ b/lib/ambi_web/router.ex
@@ -26,6 +26,11 @@ defmodule AmbiWeb.Router do
 
     # API endpoint to add a new sensor reading to the database
     post "/readings/add", ApiController, :add_reading
+
+    # API endpoint to set general reading metadata (e.g. timestamp resolution in secs)
+    post "/reading_metadata/set", ApiController, :set_metadata
+
+    # API endpoint that clear out the DB of all readings
     get "/readings/reset", ApiController, :reset
   end
 

--- a/priv/repo/migrations/20210516202131_create_reading_metadata.exs
+++ b/priv/repo/migrations/20210516202131_create_reading_metadata.exs
@@ -1,0 +1,9 @@
+defmodule Ambi.Repo.Migrations.CreateReadingMetadata do
+  use Ecto.Migration
+
+  def change do
+    create table(:reading_metadata) do
+      add :timestamp_resolution_seconds, :integer
+    end
+  end
+end


### PR DESCRIPTION
1. Display as a bar chart the avg humidity values over the last 24 hours as 24 1 hour segments.
2. Also add an API endpoint to store the IoT sensor update frequency as metadata. For example, if the IoT sensor code reads all sensors every 10 seconds and calls the /readings/add endpoint, it'll pass 10 seconds to the /reading_metadata/set endpoint.